### PR TITLE
feat: inject `globalThis.agoricPowerbox` object before scripts run

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,8 +18,6 @@ Open a tab to `test-dapp.html` in the current directory.
 npm run demo # This listens on localhost:8000
 ```
 
-Click on the "my wallet is found at" link.
-
 # UPSTREAM: browser-extension-template
 
 [link-webext-polyfill]: https://github.com/mozilla/webextension-polyfill

--- a/source/browser-messages.js
+++ b/source/browser-messages.js
@@ -18,10 +18,15 @@ export const makeBrowserMessageHandler = ({
         const { defaultUrl } = await getOptions();
         const { port1, port2 } = new MessageChannel();
         const url = new URL('/wallet-bridge.html', defaultUrl);
-        const disconnect = connect({ port: port1, url: url.href, connectId });
+        const disconnect = connect({
+          port: port1,
+          clientOrigin: location.origin,
+          url: url.href,
+          connectId,
+        });
         if (disconnect) {
           port2.addEventListener('message', ev => {
-            if (ev.data && ev.data.type === 'AGORIC_POWERBOX_DISCONNECTED') {
+            if (ev.data && ev.data.type === 'AGORIC_CLIENT_DISCONNECTED') {
               disconnect();
             }
           });

--- a/source/browser-messages.js
+++ b/source/browser-messages.js
@@ -1,0 +1,63 @@
+/* global MessageChannel */
+import { assertAgoricId } from './petdata.js';
+import { checkPrivileged } from './privs.js';
+
+export const makeBrowserMessageHandler = ({
+  connect,
+  location,
+  refreshPetdata,
+  refreshPrivileged,
+  getOptions,
+  setOptions,
+  send,
+}) => {
+  return async obj => {
+    switch (obj.type) {
+      case 'AGORIC_POWERBOX_CONNECT': {
+        const { connectId } = obj;
+        const { defaultUrl } = await getOptions();
+        const { port1, port2 } = new MessageChannel();
+        const url = new URL('/wallet-bridge.html', defaultUrl);
+        const disconnect = connect({ port: port1, url: url.href, connectId });
+        if (disconnect) {
+          port2.addEventListener('message', ev => {
+            if (ev.data && ev.data.type === 'AGORIC_POWERBOX_DISCONNECTED') {
+              disconnect();
+            }
+          });
+        }
+
+        send({ type: 'AGORIC_POWERBOX_CONNECTING', connectId }, [port2]);
+        break;
+      }
+      case 'AGORIC_POWERBOX_EXPAND_PETDATA': {
+        const { petdata = {}, powerboxUrls = [] } = await getOptions();
+        const privileged = checkPrivileged({
+          location,
+          powerboxUrls,
+        });
+        refreshPetdata({ privileged, petdata }, true);
+        refreshPrivileged({ privileged }, true);
+        break;
+      }
+      case 'AGORIC_POWERBOX_SET_PETDATA': {
+        const { petdata = {}, powerboxUrls = [] } = await getOptions();
+        if (checkPrivileged({ location, powerboxUrls })) {
+          const { id, petdata: rawPet } = obj;
+          const pet = {};
+          assertAgoricId(id);
+          Object.entries(rawPet).forEach(([k, v]) => {
+            assertAgoricId(k);
+            if (typeof v === 'string' && v) {
+              pet[k] = v;
+            }
+          });
+          petdata[id] = pet;
+          await setOptions({ petdata: { ...petdata } });
+        }
+        break;
+      }
+      default:
+    }
+  };
+};

--- a/source/connect.js
+++ b/source/connect.js
@@ -1,5 +1,44 @@
 /* global globalThis */
-export const DEFAULT_CONNECTION_TIMEOUT = 5000;
+export const DEFAULT_CONNECTION_TIMEOUT_MS = 5000;
+
+const makeQueuedSender = rawSend => {
+  let sendQ = [];
+  return {
+    send: obj => {
+      if (sendQ) {
+        sendQ.push(obj);
+        return;
+      }
+      rawSend(obj);
+    },
+    flush: () => {
+      if (sendQ) {
+        sendQ.forEach(obj => rawSend(obj));
+        sendQ = null;
+      }
+    },
+  };
+};
+
+const makeForcedInitSender = (rawSend, initPacket) => {
+  let initSent = false;
+  const qs = makeQueuedSender(rawSend);
+  return {
+    ...qs,
+    send: obj => {
+      if (obj && obj.type === initPacket.type) {
+        // Ensure the init message is first and formatted correctly.
+        obj = initPacket;
+        initSent = true;
+      }
+      if (initSent) {
+        qs.send(obj);
+        return;
+      }
+      console.info(`${initPacket.type} not sent yet, dropping ${obj.type}`);
+    },
+  };
+};
 
 export const makeConnect = ({
   document = globalThis.document,
@@ -11,17 +50,19 @@ export const makeConnect = ({
    * @param {Object} opts
    * @param {MessagePort} opts.port
    * @param {string} opts.url
+   * @param {string} opts.clientOrigin
    * @param {(...args: any[]) => void} opts.log
-   * @param {number} opts.connectionTimeout
+   * @param {number} opts.connectionTimeoutMs
    */
   return ({
     port,
+    clientOrigin,
     url,
     log = (...args) => console.log(...args),
-    connectionTimeout = DEFAULT_CONNECTION_TIMEOUT,
+    connectionTimeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS,
   } = {}) => {
     const disconnect = () => {
-      port.postMessage({ type: 'AGORIC_POWERBOX_DISCONNECT' });
+      port.postMessage({ type: 'AGORIC_POWERBOX_DISCONNECTED' });
       port.close();
     };
 
@@ -37,6 +78,12 @@ export const makeConnect = ({
     shadowRoot.appendChild(iframe);
     document.body.appendChild(shadow);
 
+    const toClient = makeQueuedSender(obj => port.postMessage(obj));
+    const fromClient = makeForcedInitSender(
+      obj => iframe.contentWindow.postMessage(obj, origin),
+      { type: 'AGORIC_CLIENT_INIT', clientOrigin },
+    );
+
     let openTimeout;
     const messageHandler = ev => {
       if (ev.source !== iframe.contentWindow) {
@@ -45,9 +92,10 @@ export const makeConnect = ({
       if (openTimeout) {
         clearTimeout(openTimeout);
         openTimeout = null;
-        port.postMessage({ type: 'AGORIC_POWERBOX_CONNECTED' });
+        fromClient.flush();
+        toClient.send({ type: 'AGORIC_POWERBOX_CONNECTED' });
       }
-      port.postMessage(ev.data);
+      toClient.send(ev.data);
     };
 
     window.addEventListener('message', messageHandler);
@@ -64,11 +112,12 @@ export const makeConnect = ({
       openTimeout = null;
       log('Connection timeout');
       errorHandler(new Error('Connection timeout'));
-    }, connectionTimeout);
+    }, connectionTimeoutMs);
 
     port.addEventListener('message', ev => {
+      toClient.flush();
       try {
-        iframe.contentWindow.postMessage(ev.data, origin);
+        fromClient.send(ev.data);
       } catch (err) {
         errorHandler(err);
       }

--- a/source/content.js
+++ b/source/content.js
@@ -1,60 +1,44 @@
-/* global window, document, MessageChannel */
+/* global window, document */
 /* eslint-disable import/no-extraneous-dependencies */
 import browser from 'webextension-polyfill';
 
 import optionsStorage from './options-storage.js';
 
 import { makeConnect } from './connect.js';
-import { assertAgoricId, makeRefreshPetdata } from './petdata.js';
+import { makeRefreshPetdata } from './petdata.js';
 import { checkPrivileged, makeRefreshPrivileged } from './privs.js';
+import { createAgoricPowerboxInBrowser } from './powerbox.js';
+import { makeInjectScript } from './inject.js';
+import { makeBrowserMessageHandler } from './browser-messages.js';
 
-const send = (o, ...opts) => {
-  console.log('content', o);
-  window.postMessage(o, '*', ...opts);
-};
+const injectScript = makeInjectScript({ document });
+const send = (o, ...opts) => window.postMessage(o, '*', ...opts);
 const refreshPetdata = makeRefreshPetdata({ send, document });
 const refreshPrivileged = makeRefreshPrivileged({ send });
 const connect = makeConnect({ document, window });
 
-window.addEventListener('message', async ev => {
-  const obj = ev.data;
-  switch (obj.type) {
-    case 'AGORIC_POWERBOX_CONNECT': {
-      const { defaultUrl } = await optionsStorage.getAll();
-      const { port1, port2 } = new MessageChannel();
-      const url = new URL('/wallet-bridge.html', defaultUrl);
-      connect({ port: port1, url: url.href });
-      send({ type: 'AGORIC_POWERBOX_CONNECTING' }, [port2]);
-      break;
-    }
-    case 'AGORIC_POWERBOX_EXPAND_PETDATA': {
-      const { petdata = {}, powerboxUrls = [] } = await optionsStorage.getAll();
-      const privileged = checkPrivileged({
-        location: window.location,
-        powerboxUrls,
-      });
-      refreshPetdata({ privileged, petdata }, true);
-      refreshPrivileged({ privileged }, true);
-      break;
-    }
-    case 'AGORIC_POWERBOX_SET_PETDATA': {
-      const { petdata = {}, powerboxUrls = [] } = await optionsStorage.getAll();
-      if (checkPrivileged({ location: window.location, powerboxUrls })) {
-        const { id, petdata: rawPet } = obj;
-        const pet = {};
-        assertAgoricId(id);
-        Object.entries(rawPet).forEach(([k, v]) => {
-          assertAgoricId(k);
-          if (typeof v === 'string' && v) {
-            pet[k] = v;
-          }
-        });
-        petdata[id] = pet;
-        await optionsStorage.set({ petdata: { ...petdata } });
-      }
-      break;
-    }
-    default:
+// If the injection throws, refuse to listen to messages.
+try {
+  injectScript(
+    `globalThis.agoricPowerbox = (${createAgoricPowerboxInBrowser})(window);`,
+  );
+} catch (e) {
+  console.error('Failed to inject agoricPowerbox:', e);
+  throw e;
+}
+
+const browserMessageHandler = makeBrowserMessageHandler({
+  connect,
+  location: window.location,
+  refreshPetdata,
+  refreshPrivileged,
+  getOptions: () => optionsStorage.getAll(),
+  setOptions: options => optionsStorage.set(options),
+  send,
+});
+window.addEventListener('message', ev => {
+  if (ev.source === window) {
+    browserMessageHandler(ev.data);
   }
 });
 

--- a/source/inject.js
+++ b/source/inject.js
@@ -1,0 +1,18 @@
+/* global globalThis */
+
+export const makeInjectScript = ({ document = globalThis.document }) => {
+  /**
+   * Thanks to MetaMask for this snippet to inject a script for immediate
+   * evaluation before any other page scripts.
+   *
+   * @param {string} content
+   */
+  return content => {
+    const container = document.head || document.documentElement;
+    const scriptTag = document.createElement('script');
+    scriptTag.setAttribute('async', false);
+    scriptTag.textContent = content;
+    container.insertBefore(scriptTag, container.children[0]);
+    container.removeChild(scriptTag);
+  };
+};

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -23,6 +23,7 @@
 	},
   "content_scripts": [{
     "matches": ["<all_urls>"],
+    "run_at": "document_start",
     "js": ["content.js"]
   }]
 }

--- a/source/powerbox.js
+++ b/source/powerbox.js
@@ -82,6 +82,7 @@ export const createAgoricPowerboxInBrowser = ({ window }) => {
             .catch(noop);
         });
         port.start();
+        port.postMessage({ type: 'AGORIC_CLIENT_INIT' });
         resolve(port);
         break;
       }
@@ -113,12 +114,12 @@ export const createAgoricPowerboxInBrowser = ({ window }) => {
       return freeze({
         send: freeze(async o => {
           const port = await portP;
-          port.postMessage(o, '*');
+          port.postMessage(o);
         }),
         disconnect: freeze(async () => {
           const port = await portP;
           port.postMessage({
-            type: 'AGORIC_POWERBOX_DISCONNECTED',
+            type: 'AGORIC_CLIENT_DISCONNECTED',
           });
           port.close();
         }),

--- a/source/powerbox.js
+++ b/source/powerbox.js
@@ -1,0 +1,149 @@
+/**
+ * Create a object that speaks to this Agoric Power Box Extension.
+ *
+ * NOTE: You may be tempted to break up this function, but it is designed to be
+ * evaluated as a string.  Therefore, it must not directly reach for any
+ * functions or globals which aren't available in a standard JavaScript
+ * environment.
+ *
+ * @param {Window} window the browser window
+ * @returns {void}
+ */
+export const createAgoricPowerboxInBrowser = ({ window }) => {
+  const { apply } = Reflect;
+  const { postMessage } = window;
+  const PromiseConstructor = Promise;
+  const { freeze } = Object;
+  const connectIdToConnection = new Map();
+
+  const noop = () => {};
+  const uncurryThis = fn => (thisArg, ...args) => apply(fn, thisArg, args);
+
+  const promiseResolve = uncurryThis(PromiseConstructor.resolve);
+
+  const dispatchCache = {};
+  const dispatchPetdata = ({
+    petdata = dispatchCache.petdata,
+    onPetdata = dispatchCache.onPetdata,
+  }) => {
+    dispatchCache.petdata = petdata;
+    dispatchCache.onPetdata = onPetdata;
+    if (petdata === undefined || onPetdata === undefined) {
+      return;
+    }
+    promiseResolve(PromiseConstructor, petdata)
+      .then(onPetdata)
+      .catch(noop);
+  };
+
+  const dispatchPrivileged = ({
+    isPrivileged = dispatchCache.isPrivileged,
+    onPrivileged = dispatchCache.onPrivileged,
+    resolvePrivileged = dispatchCache.resolvePrivileged,
+  }) => {
+    dispatchCache.isPrivileged = isPrivileged;
+    dispatchCache.onPrivileged = onPrivileged;
+    dispatchCache.resolvePrivileged = resolvePrivileged;
+    if (isPrivileged === undefined) {
+      return;
+    }
+    const p = promiseResolve(PromiseConstructor, isPrivileged);
+    if (onPrivileged !== undefined) {
+      p.then(onPrivileged).catch(noop);
+    }
+    if (resolvePrivileged !== undefined) {
+      p.then(resolvePrivileged).catch(noop);
+    }
+  };
+
+  let resolvePowerboxReady;
+  const powerboxReadyP = new PromiseConstructor(resolve => {
+    resolvePowerboxReady = resolve;
+  });
+  window.addEventListener('message', ev => {
+    if (ev.source !== window) {
+      return;
+    }
+    const obj = ev.data;
+    switch (obj.type) {
+      case 'AGORIC_POWERBOX_PAGE_IS_PRIVILEGED': {
+        const { isPrivileged } = obj;
+        dispatchPrivileged({ isPrivileged });
+        break;
+      }
+      case 'AGORIC_POWERBOX_CONNECTING': {
+        const { connectId } = obj;
+        const { resolve, dispatch } = connectIdToConnection.get(connectId);
+        connectIdToConnection.delete(connectId);
+        const port = ev.ports[0];
+        port.addEventListener('message', e => {
+          promiseResolve(PromiseConstructor, e.data)
+            .then(dispatch)
+            .catch(noop);
+        });
+        port.start();
+        resolve(port);
+        break;
+      }
+      case 'AGORIC_POWERBOX_PETDATA': {
+        const { petdata } = obj;
+        dispatchPetdata({ petdata });
+        break;
+      }
+      case 'AGORIC_POWERBOX_READY': {
+        resolvePowerboxReady();
+        break;
+      }
+      default:
+    }
+  });
+
+  let lastConnectId = 0;
+  const agoricPowerbox = freeze({
+    connect: dispatch => {
+      lastConnectId += 1;
+      const connectId = lastConnectId;
+      const portP = new PromiseConstructor((resolve, reject) => {
+        connectIdToConnection.set(connectId, { dispatch, resolve, reject });
+      });
+      // Don't actually try to connect until the powerbox is ready.
+      powerboxReadyP.then(() =>
+        postMessage({ type: 'AGORIC_POWERBOX_CONNECT', connectId }),
+      );
+      return freeze({
+        send: freeze(async o => {
+          const port = await portP;
+          port.postMessage(o, '*');
+        }),
+        disconnect: freeze(async () => {
+          const port = await portP;
+          port.postMessage({
+            type: 'AGORIC_POWERBOX_DISCONNECTED',
+          });
+          port.close();
+        }),
+      });
+    },
+    expandPetdata: onPetdata => {
+      powerboxReadyP.then(() => {
+        postMessage({ type: 'AGORIC_POWERBOX_EXPAND_PETDATA' });
+        dispatchPetdata({ onPetdata });
+      });
+    },
+    setPetdata: (id, petdata) => {
+      powerboxReadyP.then(() => {
+        postMessage({ type: 'AGORIC_POWERBOX_SET_PETDATA', id, petdata });
+      });
+    },
+    isPrivileged: onPrivileged => {
+      return new PromiseConstructor(resolvePrivileged => {
+        dispatchPrivileged({ onPrivileged, resolvePrivileged });
+      });
+    },
+    isReady: () => {
+      return powerboxReadyP;
+    },
+  });
+
+  return agoricPowerbox;
+};

--- a/source/privs.js
+++ b/source/privs.js
@@ -27,7 +27,6 @@ export const checkPrivileged = ({
   location = window.location,
   powerboxUrls = [],
 } = {}) => {
-  console.log({ location, powerboxUrls });
   const href = location.href;
   const origin = location.origin;
   for (const allowedUrl of powerboxUrls) {

--- a/test-dapp.html
+++ b/test-dapp.html
@@ -1,3 +1,12 @@
+<script type="text/javascript">
+  // Wire up a dapp in three lines:
+  agoricPowerbox.expandPetdata();
+  const conn = agoricPowerbox.connect(o => {
+    console.log('dapp received', o);
+    // conn.disconnect();
+  });
+</script>
+
 <style>
 [data-agoric-target="img"], [data-agoric-target="img-if-known"] {
   display: inline-block;
@@ -29,31 +38,3 @@
   <div data-agoric-target="img" data-agoric-id="AG.n">AG.n</div>
   <span data-agoric-target="text" data-agoric-id="AG.n"></span>
 </p>
-
-<script type="text/javascript">
-window.addEventListener('message', ev => {
-  const obj = ev.data;
-  switch (obj.type) {
-    case 'AGORIC_POWERBOX_READY': {
-      window.postMessage({ type: 'AGORIC_POWERBOX_EXPAND_PETDATA' }, '*');
-      window.postMessage({ type: 'AGORIC_POWERBOX_CONNECT' }, '*');
-      break;
-    }
-    case 'AGORIC_POWERBOX_CONNECTING': {
-      const port = ev.ports[0];
-      port.addEventListener('message', e => {
-        console.log('port received', e.data);
-        port.postMessage(e.data);
-      });
-      port.start();
-      break;
-    }
-    case 'AGORIC_POWERBOX_URL': {
-      const wlt = document.getElementById('powerboxLink');
-      wlt.innerText = ev.data.url;
-      wlt.href = ev.data.url;
-      break;
-    }
-  }
-});
-</script>


### PR DESCRIPTION
Take a look at the `test-dapp.html` to see the drastic simplification in API.

I get the following messages when connecting to an Agoric Wallet at https://localhost:8000/wallet/

![image](https://user-images.githubusercontent.com/457244/146630557-81466183-7b38-4ef4-8b95-9975d889717d.png)
